### PR TITLE
feat: add electron desktop support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,14 @@ Currently, two official plugins are available:
 - [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
 - [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
 
+## Desktop version
+
+Build and launch the app in a desktop window with Electron:
+
+```
+npm run desktop
+```
+
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:

--- a/electron.js
+++ b/electron.js
@@ -1,0 +1,25 @@
+import { app, BrowserWindow } from 'electron'
+import { join } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url))
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600
+  })
+  win.loadFile(join(__dirname, 'dist/index.html'))
+}
+
+app.whenReady().then(() => {
+  createWindow()
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+  })
+})
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit()
+})

--- a/package.json
+++ b/package.json
@@ -2,12 +2,14 @@
   "name": "jira-folder-board",
   "private": true,
   "version": "0.0.0",
+  "main": "electron.js",
   "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "desktop": "npm run build && electron ."
   },
   "dependencies": {
     "react": "^19.1.1",
@@ -24,6 +26,7 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "electron": "^32.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add electron main process and load built app
- add desktop npm script and electron dependency
- document how to launch desktop version

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 30 errors, 2 warnings)
- `npm run build` (fails: TS7053 etc.)

------
https://chatgpt.com/codex/tasks/task_e_68a750bfd38c832c840fa74cc06aff12