### PR TITLE
Expand app container width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,5 +1,5 @@
 #root {
-  max-width: 1280px;
+  width: 90vw;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;


### PR DESCRIPTION
## Summary
- expand root container to 90% viewport width so content fills more of the screen

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a8539eb96c832c9219a5a346839014