### PR TITLE
feat: add hover border effect to cards

### DIFF
--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -49,7 +49,7 @@ export default function Column({ stageKey, title, items, onOpen, onDropCard, onN
           <button
             key={i}
             onClick={() => onOpen(c)}
-            draggable                
+            draggable
             onDragStart={(e) => {
               e.dataTransfer.setData('text/plain', JSON.stringify({
                 stage: c.stage,
@@ -57,7 +57,7 @@ export default function Column({ stageKey, title, items, onOpen, onDropCard, onN
               }));
               e.dataTransfer.dropEffect = 'move';
             }}
-            style={{ textAlign: 'left', background: '#111', border: '1px solid #2a2a2a', borderRadius: 10, padding: 10, cursor: 'grab' }}
+            className="ticket-card"
           >
             <div style={{ fontWeight: 600 }}>{c.title}</div>
             <div style={{ fontSize: 12, opacity: .75, marginTop: 4 }}>

--- a/src/index.css
+++ b/src/index.css
@@ -66,3 +66,16 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.ticket-card {
+  text-align: left;
+  background: #111;
+  border: 1px solid #2a2a2a;
+  border-radius: 10px;
+  padding: 10px;
+  cursor: grab;
+  transition: border-color 0.25s;
+}
+.ticket-card:hover {
+  border-color: #646cff;
+}


### PR DESCRIPTION
## Summary
- add ticket-card CSS class to give cards a colored border on hover
- use new class for card buttons in columns

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run lint` *(fails: 24 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8653b3530832c9d0c24daf79910f2