### PR TITLE
Add toast notifications for file operations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import type { TicketCard } from './types/board';
 import { loadBoardDynamic } from './services/boardService';
 import { canUseFS, createCardInStage, moveCardToStageName, pickRootDir, verifyPermission } from './services/fsWeb';
 import { saveRootHandle, loadRootHandle, clearRootHandle } from './services/handleStore';
+import { Toaster, toast } from './utils/toast';
 import Board from './components/Board';
 import CardModal from './components/CardModal';
 import './App.css';
@@ -85,9 +86,10 @@ function App() {
     try {
       await moveCardToStageName(card, root, targetStage);
       await doLoad(); // recarrega a UI após mover
+      toast.success('Card movido com sucesso');
     } catch (e) {
       console.error(e);
-      // opcional: toast/alert
+      toast.error('Erro ao mover o card');
     }
   };
 
@@ -98,20 +100,33 @@ function App() {
 
   const doCreateCard = async (folderTitle: string, description: string) => {
     if (!root || !newStage) return;
-    await createCardInStage(root, newStage, folderTitle, description, true);
-    await doLoad();
+    try {
+      await createCardInStage(root, newStage, folderTitle, description, true);
+      await doLoad();
+      toast.success('Card criado com sucesso');
+    } catch (e) {
+      console.error(e);
+      toast.error('Erro ao criar o card');
+    }
   };
 
   const doCreateStage = async (stageName: string) => {
     if (!root) return;
     const ok = await verifyPermission(root, 'readwrite');
     if (!ok) { setErr('Sem permissão para criar pasta.'); return; }
-    await root.getDirectoryHandle(stageName, { create: true });
-    await doLoad();
+    try {
+      await root.getDirectoryHandle(stageName, { create: true });
+      await doLoad();
+      toast.success('Lista criada com sucesso');
+    } catch (e) {
+      console.error(e);
+      toast.error('Erro ao criar a lista');
+    }
   };
 
   return (
     <div style={{ padding: 16 }}>
+      <Toaster />
       <h1>Taskly</h1>
       {root && (
         <div style={{ fontSize: 13, opacity: .8, marginBottom: 12, display:'flex', gap:8, alignItems:'center' }}>

--- a/src/components/CardModal.tsx
+++ b/src/components/CardModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import Modal from './Modal';
 import type { TicketCard } from '../types/board';
 import { addAttachment, openAttachment, saveDescription, addComment } from '../services/fsWeb'; // <- add addComment
+import { toast } from '../utils/toast';
 import type { StageKey } from '../types/common';
 
 interface CardModalProps {
@@ -43,6 +44,10 @@ export default function CardModal({ open, card, onClose, onSaved }: CardModalPro
     try {
       await saveDescription(card, text ?? '');
       onSaved();
+      toast.success('Descrição salva');
+    } catch (e) {
+      console.error(e);
+      toast.error('Erro ao salvar descrição');
     } finally {
       setSaving(false);
     }
@@ -54,6 +59,10 @@ export default function CardModal({ open, card, onClose, onSaved }: CardModalPro
     try {
       await addAttachment(card);
       onSaved();
+      toast.success('Anexo adicionado');
+    } catch (e) {
+      console.error(e);
+      toast.error('Erro ao adicionar anexo');
     } finally {
       setAdding(false);
     }
@@ -68,6 +77,10 @@ export default function CardModal({ open, card, onClose, onSaved }: CardModalPro
       await addComment(card, msg);
       setNewComment('');
       onSaved(); // recarrega e puxa comments.txt atualizado
+      toast.success('Comentário adicionado');
+    } catch (e) {
+      console.error(e);
+      toast.error('Erro ao adicionar comentário');
     } finally {
       setAddingComment(false);
     }

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+
+let container: HTMLDivElement | null = null;
+
+function ensureContainer() {
+  if (!container) {
+    container = document.createElement('div');
+    container.style.position = 'fixed';
+    container.style.top = '10px';
+    container.style.right = '10px';
+    container.style.display = 'grid';
+    container.style.gap = '8px';
+    container.style.zIndex = '9999';
+    document.body.appendChild(container);
+  }
+}
+
+function show(type: 'success' | 'error', message: string) {
+  ensureContainer();
+  const div = document.createElement('div');
+  div.textContent = message;
+  div.style.padding = '8px 12px';
+  div.style.borderRadius = '4px';
+  div.style.color = '#fff';
+  div.style.background = type === 'success' ? '#16a34a' : '#dc2626';
+  div.style.boxShadow = '0 2px 6px rgba(0,0,0,0.4)';
+  container!.appendChild(div);
+  setTimeout(() => {
+    div.remove();
+    if (container && container.childElementCount === 0) {
+      container.remove();
+      container = null;
+    }
+  }, 3000);
+}
+
+export const toast = {
+  success: (msg: string) => show('success', msg),
+  error: (msg: string) => show('error', msg),
+};
+
+export function Toaster() {
+  useEffect(() => { ensureContainer(); }, []);
+  return null;
+}


### PR DESCRIPTION
## Summary
- add minimal toast utility
- show toast.success/toast.error in Portuguese when creating cards or lists, moving cards, and editing card details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 24 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68acb430d6b4832ca6c71eee76f5316f