### PR TITLE
Add help page and routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -1058,6 +1059,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2897,6 +2907,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,14 @@
-import { Link, Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import BoardPage from './pages/BoardPage';
 import Help from './pages/Help';
 
 export default function App() {
   return (
     <div>
-      <nav style={{ padding: 16, display: 'flex', gap: 8 }}>
-        <Link to="/">Início</Link>
-        <Link to="/ajuda">Ajuda</Link>
-      </nav>
       <Routes>
         <Route path="/" element={<BoardPage />} />
         <Route path="/ajuda" element={<Help />} />
+        <Route path="/*" element={<BoardPage />} />
       </Routes>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,176 +1,18 @@
-import { useEffect, useState } from 'react';
-import { loadConfig } from './config/appConfig';
-import type { AppConfig } from './types/common';
-import type { DynamicBoardData } from './services/boardService';
-import type { TicketCard } from './types/board';
-import { loadBoardDynamic } from './services/boardService';
-import { canUseFS, createCardInStage, moveCardToStageName, pickRootDir, verifyPermission } from './services/fsWeb';
-import { saveRootHandle, loadRootHandle, clearRootHandle } from './services/handleStore';
-import { Toaster, toast } from './utils/toast';
-import Board from './components/Board';
-import CardModal from './components/CardModal';
-import './App.css';
-import NewCardModal from './components/NewCardModal';
-import NewStageModal from './components/NewStageModal';
+import { Link, Route, Routes } from 'react-router-dom';
+import BoardPage from './pages/BoardPage';
+import Help from './pages/Help';
 
-function App() {
-  const [config, setConfig] = useState<AppConfig | null>(null);
-  const [root, setRoot] = useState<FileSystemDirectoryHandle | null>(null);
-  const [board, setBoard] = useState<DynamicBoardData | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [err, setErr] = useState<string>("");
-  const [activeCard, setActiveCard] = useState<TicketCard | null>(null);
-  const [newStage, setNewStage] = useState<string | null>(null);
-  const [showNewModal, setShowNewModal] = useState(false);
-  const [showStageModal, setShowStageModal] = useState(false);
-
-  useEffect(() => { loadConfig().then(setConfig); }, []);
-
-  useEffect(() => {
-    if (!config) return;
-    (async () => {
-      setErr("");
-      if (canUseFS) {
-        const saved = await loadRootHandle().catch(() => null);
-        if (saved) {
-          const ok = await verifyPermission(saved, 'readwrite');
-          if (ok) { setRoot(saved); return; }
-          await clearRootHandle().catch(() => {});
-        }
-      }
-    })();
-  }, [config]);
-
-  async function doLoad() {
-    if (!root) return;
-    setLoading(true);
-    try {
-      const b = await loadBoardDynamic(root);
-      setBoard(b);
-      if (activeCard) {
-        const flat = Object.entries(b.itemsByStage)
-          .flatMap(([stage, arr]) => arr.map(c => ({ stage, name: c.folderHandle.name, c })));
-        const refreshed = flat.find(x => activeCard &&
-          x.stage === activeCard.stage &&
-          x.name === activeCard.folderHandle.name
-        );
-        if (refreshed) setActiveCard(refreshed.c);
-        else setActiveCard(null);
-      }
-    } catch (e:any) {
-      setErr(e?.message ?? 'Falha ao ler pastas');
-    } finally {
-      setLoading(false);
-    }
-  }
-  useEffect(() => { doLoad(); /* eslint-disable-next-line */ }, [root]);
-
-  async function chooseRoot() {
-    const h = await pickRootDir();
-    if (!h) return;
-    const ok = await verifyPermission(h, 'readwrite');
-    if (!ok) { setErr('Sem permissão para acessar a pasta.'); return; }
-    await saveRootHandle(h).catch(() => {});
-    setRoot(h);
-  }
-
-  const handleDropCard = async (targetStage: string, payload: { stage: string; name: string }) => {
-    if (!root || !board) return;
-    if (payload.stage === targetStage) return;
-
-    // acha o card no board atual usando stage + nome da pasta
-    const sourceList = board.itemsByStage[payload.stage] || [];
-    const card = sourceList.find(c => c.folderHandle.name === payload.name);
-    if (!card) return;
-
-    try {
-      await moveCardToStageName(card, root, targetStage);
-      await doLoad(); // recarrega a UI após mover
-      toast.success('Card movido com sucesso');
-    } catch (e) {
-      console.error(e);
-      toast.error('Erro ao mover o card');
-    }
-  };
-
-  const handleNewCard = (stageKey: string) => {
-    setNewStage(stageKey);
-    setShowNewModal(true);
-  };
-
-  const doCreateCard = async (folderTitle: string, description: string) => {
-    if (!root || !newStage) return;
-    try {
-      await createCardInStage(root, newStage, folderTitle, description, true);
-      await doLoad();
-      toast.success('Card criado com sucesso');
-    } catch (e) {
-      console.error(e);
-      toast.error('Erro ao criar o card');
-    }
-  };
-
-  const doCreateStage = async (stageName: string) => {
-    if (!root) return;
-    const ok = await verifyPermission(root, 'readwrite');
-    if (!ok) { setErr('Sem permissão para criar pasta.'); return; }
-    try {
-      await root.getDirectoryHandle(stageName, { create: true });
-      await doLoad();
-      toast.success('Lista criada com sucesso');
-    } catch (e) {
-      console.error(e);
-      toast.error('Erro ao criar a lista');
-    }
-  };
-
+export default function App() {
   return (
-    <div style={{ padding: 16 }}>
-      <Toaster />
-      <h1>Taskly</h1>
-      {root && (
-        <div style={{ fontSize: 13, opacity: .8, marginBottom: 12, display:'flex', gap:8, alignItems:'center' }}>
-          <span>Pasta raiz: <strong>{(root as any).name}</strong></span>
-        </div>
-      )}
-
-      {err && <div style={{ padding:8, border:'1px solid #a33', marginBottom:12 }}>{err}</div>}
-
-      <div style={{ display:'flex', gap:8, marginBottom:12, flexWrap:'wrap' }}>
-        <button onClick={chooseRoot}>{root ? 'Trocar' : 'Escolher'} pasta</button>
-        <button onClick={() => doLoad()} disabled={!root || loading}>{loading ? 'Lendo…' : 'Recarregar'}</button>
-        <button onClick={() => { clearRootHandle(); setRoot(null); setBoard(null); setActiveCard(null); }}>
-          Esquecer pasta
-        </button>
-        <button onClick={() => setShowStageModal(true)} disabled={!root}>
-          Nova lista
-        </button>
-      </div>
-
-      {!root && <div>Selecione a pasta raiz. Cada subpasta será uma coluna (ordenadas alfabeticamente).</div>}
-
-      {board && <Board data={board} onOpenCard={setActiveCard} onDropCard={handleDropCard} onNewCard={handleNewCard}/>}
-
-      <CardModal
-        open={!!activeCard}
-        card={activeCard}
-        onClose={() => setActiveCard(null)}
-        onSaved={() => doLoad()}
-      />
-
-      <NewCardModal
-        open={showNewModal}
-        stageName={newStage}
-        onClose={() => setShowNewModal(false)}
-        onCreate={doCreateCard}
-      />
-      <NewStageModal
-        open={showStageModal}
-        onClose={() => setShowStageModal(false)}
-        onCreate={doCreateStage}
-      />
+    <div>
+      <nav style={{ padding: 16, display: 'flex', gap: 8 }}>
+        <Link to="/">Início</Link>
+        <Link to="/ajuda">Ajuda</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<BoardPage />} />
+        <Route path="/ajuda" element={<Help />} />
+      </Routes>
     </div>
   );
 }
-
-export default App;

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -38,7 +38,7 @@ export default function Column({ stageKey, title, items, onOpen, onDropCard, onN
       style={{ border: '1px solid #2a2a2a', borderRadius: 12, padding: 10, minHeight: 120 }}
     >
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 8 }}>
-        <div style={{ fontWeight: 700 }}>{title}</div>
+        <div style={{ display:'flex', gap:8, alignItems:'center', fontWeight: 700 }}>{title}</div>
         <div style={{ display:'flex', gap:8, alignItems:'center' }}>
           <span style={{ fontSize:12, opacity:.7 }}>{items.length}</span>
           <button onClick={() => onNewCard(stageKey)} title="Novo card">+ Novo</button>

--- a/src/index.css
+++ b/src/index.css
@@ -15,11 +15,11 @@
 
 a {
   font-weight: 500;
-  color: #646cff;
+  color: #2CDEBF;
   text-decoration: inherit;
 }
 a:hover {
-  color: #535bf2;
+  color: #2CDEBF;
 }
 
 body {
@@ -47,7 +47,7 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: #2CDEBF;
 }
 button:focus,
 button:focus-visible {
@@ -77,5 +77,5 @@ button:focus-visible {
   transition: border-color 0.25s;
 }
 .ticket-card:hover {
-  border-color: #646cff;
+  border-color: #2CDEBF;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )

--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from "react-router-dom";
 import { loadConfig } from '../config/appConfig';
 import type { AppConfig } from '../types/common';
 import type { DynamicBoardData } from '../services/boardService';
@@ -23,6 +24,7 @@ function BoardPage() {
   const [newStage, setNewStage] = useState<string | null>(null);
   const [showNewModal, setShowNewModal] = useState(false);
   const [showStageModal, setShowStageModal] = useState(false);
+  const navigate = useNavigate();
 
   useEffect(() => { loadConfig().then(setConfig); }, []);
 
@@ -145,6 +147,7 @@ function BoardPage() {
         <button onClick={() => setShowStageModal(true)} disabled={!root}>
           Nova lista
         </button>
+        <button onClick={() => navigate('/ajuda')}>Ajuda</button>
       </div>
 
       {!root && <div>Selecione a pasta raiz. Cada subpasta será uma coluna (ordenadas alfabeticamente).</div>}

--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -1,0 +1,176 @@
+import { useEffect, useState } from 'react';
+import { loadConfig } from '../config/appConfig';
+import type { AppConfig } from '../types/common';
+import type { DynamicBoardData } from '../services/boardService';
+import type { TicketCard } from '../types/board';
+import { loadBoardDynamic } from '../services/boardService';
+import { canUseFS, createCardInStage, moveCardToStageName, pickRootDir, verifyPermission } from '../services/fsWeb';
+import { saveRootHandle, loadRootHandle, clearRootHandle } from '../services/handleStore';
+import { Toaster, toast } from '../utils/toast';
+import Board from '../components/Board';
+import CardModal from '../components/CardModal';
+import '../App.css';
+import NewCardModal from '../components/NewCardModal';
+import NewStageModal from '../components/NewStageModal';
+
+function BoardPage() {
+  const [config, setConfig] = useState<AppConfig | null>(null);
+  const [root, setRoot] = useState<FileSystemDirectoryHandle | null>(null);
+  const [board, setBoard] = useState<DynamicBoardData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string>("");
+  const [activeCard, setActiveCard] = useState<TicketCard | null>(null);
+  const [newStage, setNewStage] = useState<string | null>(null);
+  const [showNewModal, setShowNewModal] = useState(false);
+  const [showStageModal, setShowStageModal] = useState(false);
+
+  useEffect(() => { loadConfig().then(setConfig); }, []);
+
+  useEffect(() => {
+    if (!config) return;
+    (async () => {
+      setErr("");
+      if (canUseFS) {
+        const saved = await loadRootHandle().catch(() => null);
+        if (saved) {
+          const ok = await verifyPermission(saved, 'readwrite');
+          if (ok) { setRoot(saved); return; }
+          await clearRootHandle().catch(() => {});
+        }
+      }
+    })();
+  }, [config]);
+
+  async function doLoad() {
+    if (!root) return;
+    setLoading(true);
+    try {
+      const b = await loadBoardDynamic(root);
+      setBoard(b);
+      if (activeCard) {
+        const flat = Object.entries(b.itemsByStage)
+          .flatMap(([stage, arr]) => arr.map(c => ({ stage, name: c.folderHandle.name, c })));
+        const refreshed = flat.find(x => activeCard &&
+          x.stage === activeCard.stage &&
+          x.name === activeCard.folderHandle.name
+        );
+        if (refreshed) setActiveCard(refreshed.c);
+        else setActiveCard(null);
+      }
+    } catch (e:any) {
+      setErr(e?.message ?? 'Falha ao ler pastas');
+    } finally {
+      setLoading(false);
+    }
+  }
+  useEffect(() => { doLoad(); /* eslint-disable-next-line */ }, [root]);
+
+  async function chooseRoot() {
+    const h = await pickRootDir();
+    if (!h) return;
+    const ok = await verifyPermission(h, 'readwrite');
+    if (!ok) { setErr('Sem permissão para acessar a pasta.'); return; }
+    await saveRootHandle(h).catch(() => {});
+    setRoot(h);
+  }
+
+  const handleDropCard = async (targetStage: string, payload: { stage: string; name: string }) => {
+    if (!root || !board) return;
+    if (payload.stage === targetStage) return;
+
+    // acha o card no board atual usando stage + nome da pasta
+    const sourceList = board.itemsByStage[payload.stage] || [];
+    const card = sourceList.find(c => c.folderHandle.name === payload.name);
+    if (!card) return;
+
+    try {
+      await moveCardToStageName(card, root, targetStage);
+      await doLoad(); // recarrega a UI após mover
+      toast.success('Card movido com sucesso');
+    } catch (e) {
+      console.error(e);
+      toast.error('Erro ao mover o card');
+    }
+  };
+
+  const handleNewCard = (stageKey: string) => {
+    setNewStage(stageKey);
+    setShowNewModal(true);
+  };
+
+  const doCreateCard = async (folderTitle: string, description: string) => {
+    if (!root || !newStage) return;
+    try {
+      await createCardInStage(root, newStage, folderTitle, description, true);
+      await doLoad();
+      toast.success('Card criado com sucesso');
+    } catch (e) {
+      console.error(e);
+      toast.error('Erro ao criar o card');
+    }
+  };
+
+  const doCreateStage = async (stageName: string) => {
+    if (!root) return;
+    const ok = await verifyPermission(root, 'readwrite');
+    if (!ok) { setErr('Sem permissão para criar pasta.'); return; }
+    try {
+      await root.getDirectoryHandle(stageName, { create: true });
+      await doLoad();
+      toast.success('Lista criada com sucesso');
+    } catch (e) {
+      console.error(e);
+      toast.error('Erro ao criar a lista');
+    }
+  };
+
+  return (
+    <div style={{ padding: 16 }}>
+      <Toaster />
+      <h1>Taskly</h1>
+      {root && (
+        <div style={{ fontSize: 13, opacity: .8, marginBottom: 12, display:'flex', gap:8, alignItems:'center' }}>
+          <span>Pasta raiz: <strong>{(root as any).name}</strong></span>
+        </div>
+      )}
+
+      {err && <div style={{ padding:8, border:'1px solid #a33', marginBottom:12 }}>{err}</div>}
+
+      <div style={{ display:'flex', gap:8, marginBottom:12, flexWrap:'wrap' }}>
+        <button onClick={chooseRoot}>{root ? 'Trocar' : 'Escolher'} pasta</button>
+        <button onClick={() => doLoad()} disabled={!root || loading}>{loading ? 'Lendo…' : 'Recarregar'}</button>
+        <button onClick={() => { clearRootHandle(); setRoot(null); setBoard(null); setActiveCard(null); }}>
+          Esquecer pasta
+        </button>
+        <button onClick={() => setShowStageModal(true)} disabled={!root}>
+          Nova lista
+        </button>
+      </div>
+
+      {!root && <div>Selecione a pasta raiz. Cada subpasta será uma coluna (ordenadas alfabeticamente).</div>}
+
+      {board && <Board data={board} onOpenCard={setActiveCard} onDropCard={handleDropCard} onNewCard={handleNewCard}/>}
+
+      <CardModal
+        open={!!activeCard}
+        card={activeCard}
+        onClose={() => setActiveCard(null)}
+        onSaved={() => doLoad()}
+      />
+
+      <NewCardModal
+        open={showNewModal}
+        stageName={newStage}
+        onClose={() => setShowNewModal(false)}
+        onCreate={doCreateCard}
+      />
+      <NewStageModal
+        open={showStageModal}
+        onClose={() => setShowStageModal(false)}
+        onCreate={doCreateStage}
+      />
+    </div>
+  );
+}
+
+export default BoardPage;

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+
+export default function Help() {
+  return (
+    <div style={{ padding: 16 }}>
+      <h1>Ajuda</h1>
+      <p>
+        Esta aplicação lê uma pasta do seu computador e transforma as subpastas
+        em listas de tarefas. Cada subpasta dentro de uma lista vira um card.
+      </p>
+      <ul>
+        <li>Clique em <strong>Escolher pasta</strong> para selecionar a raiz do board.</li>
+        <li>Arraste os cards entre as listas para mudar de etapa.</li>
+        <li>Use <strong>Nova lista</strong> ou <strong>Novo card</strong> para criar itens.</li>
+      </ul>
+      <p><Link to="/">Voltar</Link></p>
+    </div>
+  );
+}

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -2,18 +2,64 @@ import { Link } from 'react-router-dom';
 
 export default function Help() {
   return (
-    <div style={{ padding: 16 }}>
-      <h1>Ajuda</h1>
-      <p>
-        Esta aplicação lê uma pasta do seu computador e transforma as subpastas
-        em listas de tarefas. Cada subpasta dentro de uma lista vira um card.
+    <div
+      style={{
+        maxWidth: 800,
+        margin: '0 auto',
+        padding: '2rem',
+        lineHeight: 1.6,
+        color: '#ddd',
+      }}
+    >
+      <h1 style={{ marginBottom: '1rem', fontSize: '2rem', fontWeight: 700 }}>
+        Ajuda
+      </h1>
+
+      <p style={{ marginBottom: '1rem' }}>
+        Esta aplicação transforma uma pasta do seu computador em um <em>board</em> visual
+        de tarefas. Cada subpasta dentro da pasta raiz representa uma lista, e cada
+        subpasta dentro de uma lista se torna um card.
       </p>
-      <ul>
-        <li>Clique em <strong>Escolher pasta</strong> para selecionar a raiz do board.</li>
-        <li>Arraste os cards entre as listas para mudar de etapa.</li>
-        <li>Use <strong>Nova lista</strong> ou <strong>Novo card</strong> para criar itens.</li>
+
+      <ul style={{ marginBottom: '1rem', paddingLeft: '1.25rem' }}>
+        <li>
+          Clique em <strong>Escolher pasta</strong> para selecionar a pasta raiz do board.
+        </li>
+        <li>
+          Arraste os cards entre as listas para mover tarefas de uma etapa para outra.
+        </li>
+        <li>
+          Use <strong>Nova lista</strong> ou <strong>Novo card</strong> para criar novos itens
+          rapidamente.
+        </li>
+        <li>
+          Edite a descrição, adicione anexos ou insira comentários diretamente em cada card.
+        </li>
       </ul>
-      <p><Link to="/">Voltar</Link></p>
+
+      <div
+        style={{
+          border: '1px solid #2a2a2a',
+          borderRadius: 8,
+          padding: '1rem',
+          background: '#111',
+          marginBottom: '1rem',
+        }}
+      >
+        <h2 style={{ fontSize: '1.25rem', marginBottom: '.5rem' }}>💡 Dica extra</h2>
+        <p style={{ margin: 0 }}>
+          Como os dados ficam dentro das pastas locais, nada é salvo em um servidor.
+          Se você usar uma pasta que esteja dentro do <strong>OneDrive</strong> (ou outro serviço de nuvem como
+          Google Drive/Dropbox), poderá abrir o mesmo board em diferentes computadores,
+          desde que todos tenham acesso à pasta sincronizada.
+        </p>
+      </div>
+
+      <p>
+        <Link to="/" style={{ color: '#2CDEBF', fontWeight: 600 }}>
+          ← Voltar para o board
+        </Link>
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Integrate `react-router-dom` and wrap app with `BrowserRouter`.
- Introduce a new Ajuda help page with usage instructions in Portuguese.
- Add basic navigation and routes for home and help pages.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 26 problems, including `@typescript-eslint/no-explicit-any`)*

------
https://chatgpt.com/codex/tasks/task_e_68b83c481034832cbfbd7d762c544111