### PR TITLE
feat: add open folder option

### DIFF
--- a/src/components/CardModal.tsx
+++ b/src/components/CardModal.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import Modal from './Modal';
 import type { TicketCard } from '../types/board';
-import { addAttachment, openAttachment, saveDescription, addComment } from '../services/fsWeb'; // <- add addComment
+import { addAttachment, openAttachment, saveDescription, addComment, openFolder } from '../services/fsWeb'; // <- add addComment
 import { toast } from '../utils/toast';
 import type { StageKey } from '../types/common';
 
@@ -97,7 +97,10 @@ export default function CardModal({ open, card, onClose, onSaved }: CardModalPro
                 {card.updatedAt ? `Atualizado: ${new Date(card.updatedAt).toLocaleString()}` : 'Sem data'}
               </div>
             </div>
-            <button onClick={onClose} style={{ padding: '6px 10px' }}>Fechar</button>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button onClick={() => openFolder(card)} style={{ padding: '6px 10px' }}>Abrir Pasta</button>
+              <button onClick={onClose} style={{ padding: '6px 10px' }}>Fechar</button>
+            </div>
           </header>
 
           {/* Descrição */}

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -1,4 +1,5 @@
 import type { TicketCard } from '../types/board';
+import { openFolder } from '../services/fsWeb';
 
 interface ColumnProps {
   stageKey: string;               
@@ -46,7 +47,7 @@ export default function Column({ stageKey, title, items, onOpen, onDropCard, onN
       </div>
       <div style={{ display: 'grid', gap: 8 }}>
         {items.map((c, i) => (
-          <button
+          <div
             key={i}
             onClick={() => onOpen(c)}
             draggable
@@ -58,6 +59,7 @@ export default function Column({ stageKey, title, items, onOpen, onDropCard, onN
               e.dataTransfer.dropEffect = 'move';
             }}
             className="ticket-card"
+            role="button"
           >
             <div style={{ fontWeight: 600 }}>{c.title}</div>
             <div style={{ fontSize: 12, opacity: .75, marginTop: 4 }}>
@@ -73,7 +75,15 @@ export default function Column({ stageKey, title, items, onOpen, onDropCard, onN
                 {c.attachments.length} anexo(s)
               </div>
             )}
-          </button>
+            <div style={{ marginTop: 8 }}>
+              <button
+                onClick={(e) => { e.stopPropagation(); openFolder(c); }}
+                style={{ padding: '4px 8px' }}
+              >
+                Abrir Pasta
+              </button>
+            </div>
+          </div>
         ))}
         {items.length === 0 && <div style={{ opacity: .7, fontSize: 14 }}>Vazio</div>}
       </div>

--- a/src/services/fsWeb.ts
+++ b/src/services/fsWeb.ts
@@ -117,6 +117,16 @@ export async function verifyPermission(handle: FileSystemDirectoryHandle, mode: 
   return r === 'granted';
 }
 
+export async function openFolder(card: TicketCard): Promise<void> {
+  const ok = await verifyPermission(card.folderHandle, 'read');
+  if (!ok) return;
+  try {
+    await (window as any).showDirectoryPicker({ startIn: card.folderHandle });
+  } catch (e) {
+    console.error('Falha ao abrir pasta', e);
+  }
+}
+
 // 2) Tenta pegar a subpasta; cria se permitido em config; senão retorna null
 export async function ensureStageDir(
   root: FileSystemDirectoryHandle,


### PR DESCRIPTION
## Summary
- add open folder action for cards
- expose openFolder helper for ticket folders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c02e209db4832cb2576031ab9fd680