### PR TITLE
Add Azure Static Web Apps configuration and sitemap

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://taskly.sunsalesystem.com.br/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://taskly.sunsalesystem.com.br/ajuda</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,36 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/assets/*",
+      "/img/*",
+      "/static/*",
+      "/*.css",
+      "/*.js",
+      "/*.map",
+      "/*.png",
+      "/*.jpg",
+      "/*.jpeg",
+      "/*.svg",
+      "/favicon.ico",
+      "/robots.txt",
+      "/sitemap.xml"
+    ]
+  },
+  "responseOverrides": {
+    "404": { "rewrite": "/index.html" }
+  },
+  "globalHeaders": {
+    "X-Frame-Options": "SAMEORIGIN",
+    "X-Content-Type-Options": "nosniff"
+  },
+  "routes": [
+    { "route": "/index.html", "redirect": "/", "statusCode": 301 },
+
+    /* Opcional: mata URLs erradas herdadas de build/links antigos */
+    { "route": "/src/*", "statusCode": 410 },
+
+    /* Exemplo de correção específica (troque conforme o site) */
+    { "route": "/src/contatos.html", "redirect": "/contato", "statusCode": 301 }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Azure Static Web Apps configuration to control rewrites, headers, and redirects
- provide sitemap with entries for the main board and help pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1469a7904832c852cbcd5456408af