### PR TITLE
Add horizontal scrolling to board lists

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -12,7 +12,17 @@ interface BoardProps {
 
 export default function Board({ data, onOpenCard, onDropCard, onNewCard, onUpdateCardLegends }: BoardProps) {
   return (
-    <div style={{ display: 'grid', gridTemplateColumns: `repeat(${data.stages.length}, 1fr)`, gap: 12 }}>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'stretch',
+        gap: 12,
+        overflowX: 'auto',
+        paddingBottom: 8,
+        width: '100%',
+        maxWidth: '100%',
+      }}
+    >
       {data.stages.map(s => (
         <Column
           key={s.key}

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -150,6 +150,9 @@ export default function Column({ stageKey, title, items, legends, onOpen, onDrop
         display: 'flex',
         flexDirection: 'column',
         gap: 8,
+        minWidth: '16rem',
+        flex: '1 0 16rem',
+        maxHeight: '70vh',
       }}
     >
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 10 }}>
@@ -159,7 +162,15 @@ export default function Column({ stageKey, title, items, legends, onOpen, onDrop
           <button onClick={() => onNewCard(stageKey)} title="Novo card">+ Novo</button>
         </div>
       </div>
-      <div style={{ display: 'grid', gap: 8 }}>
+      <div
+        style={{
+          display: 'grid',
+          gap: 8,
+          flex: 1,
+          overflowY: 'auto',
+          paddingRight: 4,
+        }}
+      >
         {items.map((c, i) => (
           <button
             key={i}


### PR DESCRIPTION
## Summary
- allow the board area to scroll horizontally instead of expanding with the page
- enforce a minimum width for each column and add vertical scrolling inside the card list area

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e006f8a8d4832c908df595fe1a736e