### PR TITLE
Handle new card creation errors without closing modal

### DIFF
--- a/src/components/NewCardModal.tsx
+++ b/src/components/NewCardModal.tsx
@@ -29,6 +29,8 @@ export default function NewCardModal({ open, stageName, onClose, onCreate }: Pro
     try {
       await onCreate(title.trim(), desc);
       onClose();
+    } catch (error) {
+      // handled by onCreate
     } finally {
       setBusy(false);
     }

--- a/src/pages/BoardPage.tsx
+++ b/src/pages/BoardPage.tsx
@@ -119,6 +119,7 @@ function BoardPage() {
     } catch (e) {
       console.error(e);
       toast.error('Erro ao criar o card');
+      throw e;
     }
   };
 


### PR DESCRIPTION
## Summary
- keep the new card modal open when creation fails so user input is preserved
- propagate creation failures from the board page and swallow them in the modal handler

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f8bfb4d598832cb06690a0528a421a